### PR TITLE
Convert JSX to React.createElement

### DIFF
--- a/tweet-embed.js
+++ b/tweet-embed.js
@@ -28,14 +28,13 @@ class TweetEmbed extends React.Component {
     }
   }
   render () {
-    return <div ref={(c) => this._div = c} />
+    return React.createElement('div', { ref: (c) => this._div = c })
   }
 }
 
 TweetEmbed.propTypes = {
   id: PropTypes.string,
   options: PropTypes.object
-
 }
 
 export default TweetEmbed


### PR DESCRIPTION
Convert JSX to React.createElement in order to use module w/o extra transpiling

fixes #2 