### PR TITLE
Moved React from dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/capaj/react-tweet-embed/issues"
   },
   "homepage": "https://github.com/capaj/react-tweet-embed#readme",
-  "dependencies": {
+  "peerDependencies": {
     "react": "^15.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This avoids some instances where the application might end up  using multiple version of React. This is not supported and will cause strange behaviours and increase the bundle size.