### PR TITLE
Feature addition: Preview while Twitter is loading

### DIFF
--- a/dist/tweet-embed.js
+++ b/dist/tweet-embed.js
@@ -39,10 +39,17 @@ function addScript(src, cb) {
 var TweetEmbed = function (_React$Component) {
   _inherits(TweetEmbed, _React$Component);
 
-  function TweetEmbed() {
+  function TweetEmbed(props) {
     _classCallCheck(this, TweetEmbed);
 
-    return _possibleConstructorReturn(this, (TweetEmbed.__proto__ || Object.getPrototypeOf(TweetEmbed)).apply(this, arguments));
+    var _this = _possibleConstructorReturn(this, (TweetEmbed.__proto__ || Object.getPrototypeOf(TweetEmbed)).call(this, props));
+
+    if (_this.props.preview) {
+      _this.state = {
+        showPreview: true
+      };
+    }
+    return _this;
   }
 
   _createClass(TweetEmbed, [{
@@ -57,8 +64,15 @@ var TweetEmbed = function (_React$Component) {
       };
       if (!window.twttr) {
         addScript('//platform.twitter.com/widgets.js', renderTweet);
+
+        if (this.state.hasOwnProperty('showPreview')) {
+          callbacks.push(function () {
+            return _this2.setState({ showPreview: false });
+          });
+        }
       } else {
         renderTweet();
+        this.setState({ showPreview: false });
       }
     }
   }, {
@@ -66,9 +80,13 @@ var TweetEmbed = function (_React$Component) {
     value: function render() {
       var _this3 = this;
 
-      return _react2.default.createElement('div', { ref: function ref(c) {
-          _this3._div = c;
-        } });
+      return _react2.default.createElement(
+        'div',
+        { ref: function ref(c) {
+            _this3._div = c;
+          } },
+        this.state.showPreview && this.props.preview
+      );
     }
   }]);
 
@@ -76,8 +94,9 @@ var TweetEmbed = function (_React$Component) {
 }(_react2.default.Component);
 
 TweetEmbed.propTypes = {
-  id: _react.PropTypes.string,
-  options: _react.PropTypes.object
+  id: _react.PropTypes.string.isRequired,
+  options: _react.PropTypes.object,
+  preview: _react.PropTypes.element
 };
 
 exports.default = TweetEmbed;

--- a/dist/tweet-embed.js
+++ b/dist/tweet-embed.js
@@ -62,17 +62,18 @@ var TweetEmbed = function (_React$Component) {
       var renderTweet = function renderTweet() {
         window.twttr.widgets.createTweetEmbed(_this2.props.id, _this2._div, options);
       };
-      if (!window.twttr) {
-        addScript('//platform.twitter.com/widgets.js', renderTweet);
 
+      if (window.twttr) {
+        renderTweet();
+        this.setState({ showPreview: false });
+      } else {
         if (this.state.hasOwnProperty('showPreview')) {
           callbacks.push(function () {
             return _this2.setState({ showPreview: false });
           });
         }
-      } else {
-        renderTweet();
-        this.setState({ showPreview: false });
+
+        addScript('//platform.twitter.com/widgets.js', renderTweet);
       }
     }
   }, {

--- a/tweet-embed.js
+++ b/tweet-embed.js
@@ -35,7 +35,7 @@ class TweetEmbed extends React.Component {
     if (!window.twttr) {
       addScript('//platform.twitter.com/widgets.js', renderTweet)
 
-      if (this.state.hasOwnProperty('showPreview') {
+      if (this.state.hasOwnProperty('showPreview')) {
         callbacks.push(() => this.setState({showPreview: false}))
       }
 

--- a/tweet-embed.js
+++ b/tweet-embed.js
@@ -15,6 +15,17 @@ function addScript (src, cb) {
 }
 
 class TweetEmbed extends React.Component {
+
+  constructor(props) {
+    super(props)
+
+    if (this.props.preview) {
+      this.state = {
+        showPreview: true
+      }
+    }
+  }
+
   componentDidMount () {
     const options = this.props.options || {}
 
@@ -23,20 +34,30 @@ class TweetEmbed extends React.Component {
     }
     if (!window.twttr) {
       addScript('//platform.twitter.com/widgets.js', renderTweet)
+
+      if (this.state.hasOwnProperty('showPreview') {
+        callbacks.push(() => this.setState({showPreview: false}))
+      }
+
     } else {
       renderTweet()
+      this.setState({showPreview: false})
     }
   }
+
   render () {
-    return <div ref={(c) => {
-      this._div = c
-    }} />
+    return (
+      <div ref={(c) => { this._div = c}}>
+        { this.state.showPreview && this.props.preview }
+      </div>
+    )
   }
 }
 
 TweetEmbed.propTypes = {
-  id: PropTypes.string,
-  options: PropTypes.object
+  id: PropTypes.string.isRequired,
+  options: PropTypes.object,
+  preview: PropTypes.element
 }
 
 export default TweetEmbed

--- a/tweet-embed.js
+++ b/tweet-embed.js
@@ -32,16 +32,17 @@ class TweetEmbed extends React.Component {
     const renderTweet = () => {
       window.twttr.widgets.createTweetEmbed(this.props.id, this._div, options)
     }
-    if (!window.twttr) {
-      addScript('//platform.twitter.com/widgets.js', renderTweet)
 
+    if (window.twttr) {
+      renderTweet()
+      this.setState({showPreview: false})
+
+    } else {
       if (this.state.hasOwnProperty('showPreview')) {
         callbacks.push(() => this.setState({showPreview: false}))
       }
 
-    } else {
-      renderTweet()
-      this.setState({showPreview: false})
+      addScript('//platform.twitter.com/widgets.js', renderTweet)
     }
   }
 


### PR DESCRIPTION
Hello,

I added this for my own usage but thought it could be useful to others. If you agree I can add some documentation as well.

This change allows for a `preview` prop on the `TweetEmbed` instance. This prop will render if the Twitter script tag is not yet on the page and will disappear once the Twitter script is present.

Example:

```jsx
<TweetEmbed
  id="123456789"
  preview={<div>Loading!</div>}
/>
```