### PR TITLE
Make possible to load twitter js sdk from cordova apps

### DIFF
--- a/dist/tweet-embed.js
+++ b/dist/tweet-embed.js
@@ -55,8 +55,11 @@ var TweetEmbed = function (_React$Component) {
       var renderTweet = function renderTweet() {
         window.twttr.widgets.createTweetEmbed(_this2.props.id, _this2._div, options);
       };
+
       if (!window.twttr) {
-        addScript('//platform.twitter.com/widgets.js', renderTweet);
+        var protocol = window.location.protocol.indexOf('file') >= 0 ? this.props.defaultProtocol : '';
+
+        addScript(protocol + '//platform.twitter.com/widgets.js', renderTweet);
       } else {
         renderTweet();
       }
@@ -77,7 +80,12 @@ var TweetEmbed = function (_React$Component) {
 
 TweetEmbed.propTypes = {
   id: _react.PropTypes.string,
-  options: _react.PropTypes.object
+  options: _react.PropTypes.object,
+  defaultProtocol: _react.PropTypes.string
+};
+
+TweetEmbed.defaultProps = {
+  defaultProtocol: 'https:'
 };
 
 exports.default = TweetEmbed;

--- a/tweet-embed.js
+++ b/tweet-embed.js
@@ -21,8 +21,13 @@ class TweetEmbed extends React.Component {
     const renderTweet = () => {
       window.twttr.widgets.createTweetEmbed(this.props.id, this._div, options)
     }
+
     if (!window.twttr) {
-      addScript('//platform.twitter.com/widgets.js', renderTweet)
+      const protocol = window.location.protocol.indexOf('file') >= 0
+        ? this.props.defaultProtocol
+        : ''
+
+      addScript(`${protocol}//platform.twitter.com/widgets.js`, renderTweet)
     } else {
       renderTweet()
     }
@@ -36,7 +41,12 @@ class TweetEmbed extends React.Component {
 
 TweetEmbed.propTypes = {
   id: PropTypes.string,
-  options: PropTypes.object
+  options: PropTypes.object,
+  defaultProtocol: PropTypes.string
+}
+
+TweetEmbed.defaultProps = {
+  defaultProtocol: 'https:'
 }
 
 export default TweetEmbed


### PR DESCRIPTION
Cordova apps are served from device's file system. Hence, all ``//something.com`` resources will inherit the ``file://`` protocol by default.
This patch prevents that from happening by defaulting to ``https://``. This default can be overridden through ``defaultProtocol`` prop. 