### PR TITLE
Adds api which enables listening on tweet load lifecycle

### DIFF
--- a/__snapshots__/tweet-embed.spec.js.snap
+++ b/__snapshots__/tweet-embed.spec.js.snap
@@ -1,3 +1,3 @@
-exports[`calls twttr api 1`] = `"[\"tweet_id\",null,{\"myOption\":1}]"`;
+exports[`calls twttr api 1`] = `"["tweet_id",null,{"myOption":1}]"`;
 
-exports[`renders 1`] = `"{\"key\":null,\"ref\":null,\"props\":{\"id\":\"692527862369357824\",\"protocol\":\"https:\"},\"_owner\":null,\"_store\":{}}"`;
+exports[`renders 1`] = `"{\"key\":null,\"ref\":null,\"props\":{\"id\":\"692527862369357824\",\"protocol\":\"https:\",\"options\":{}},\"_owner\":null,\"_store\":{}}"`;

--- a/tweet-embed.js
+++ b/tweet-embed.js
@@ -16,10 +16,14 @@ function addScript (src, cb) {
 
 class TweetEmbed extends React.Component {
   componentDidMount () {
-    const options = this.props.options || {}
-
     const renderTweet = () => {
-      window.twttr.widgets.createTweetEmbed(this.props.id, this._div, options)
+      window.twttr.ready().then(({ widgets }) => {
+        const { options, onTweetLoadSuccess, onTweetLoadError } = this.props
+        widgets
+          .createTweetEmbed(this.props.id, this._div, options)
+          .then(onTweetLoadSuccess)
+          .catch(onTweetLoadError)
+      })
     }
 
     if (!window.twttr) {
@@ -32,6 +36,7 @@ class TweetEmbed extends React.Component {
       renderTweet()
     }
   }
+
   render () {
     return <div ref={(c) => {
       this._div = c
@@ -42,11 +47,14 @@ class TweetEmbed extends React.Component {
 TweetEmbed.propTypes = {
   id: PropTypes.string,
   options: PropTypes.object,
-  protocol: PropTypes.string
+  protocol: PropTypes.string,
+  onTweetLoadSuccess: PropTypes.func,
+  onTweetLoadError: PropTypes.func
 }
 
 TweetEmbed.defaultProps = {
-  protocol: 'https:'
+  protocol: 'https:',
+  options: {}
 }
 
 export default TweetEmbed

--- a/tweet-embed.spec.js
+++ b/tweet-embed.spec.js
@@ -13,10 +13,13 @@ test.cb('calls twttr api', t => {
         createTweetEmbed: (...args) => {
           t.snapshot(args)
           t.end()
+          return Promise.resolve()
         }
       }
     }
   }
+
+  global.window.twttr.ready = () => Promise.resolve(global.window.twttr)
 
   const comp = new TweetEmbed({id: 'tweet_id', options: {myOption: 1}})
   comp.componentDidMount()


### PR DESCRIPTION
This PR improves the way how tweets are loaded by first waiting ``twttr`` to fully initialize.
Additionally, two more tweet loading lifecycle listener can be passed: ``onTweetLoadSuccess`` and ``onTweetLoadError``.