### PR TITLE
Moves babel presets to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "ava": "^0.18.2",
     "babel": "^6.23.0",
     "babel-cli": "^6.24.0",
+    "babel-preset-es2015": "^6.24.0",
+    "babel-preset-react": "^6.23.0",
     "babel-preset-react-app": "^2.2.0",
     "enzyme": "^2.7.1",
     "jsdom": "^9.12.0",
@@ -50,9 +52,5 @@
     "ignore": [
       "dist/"
     ]
-  },
-  "dependencies": {
-    "babel-preset-es2015": "^6.24.0",
-    "babel-preset-react": "^6.23.0"
   }
 }


### PR DESCRIPTION
Babel presets are used only in dev mode. Having them defined in ``dependencies`` section increases the install time and download size of this package.