### PR TITLE
Updated to use the new "prop-types" package

### DIFF
--- a/dist/tweet-embed.es.js
+++ b/dist/tweet-embed.es.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const callbacks = [];
 

--- a/dist/tweet-embed.js
+++ b/dist/tweet-embed.js
@@ -10,6 +10,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -86,12 +90,12 @@ var TweetEmbed = function (_React$Component) {
 }(_react2.default.Component);
 
 TweetEmbed.propTypes = {
-  id: _react.PropTypes.string,
-  options: _react.PropTypes.object,
-  protocol: _react.PropTypes.string,
-  onTweetLoadSuccess: _react.PropTypes.func,
-  onTweetLoadError: _react.PropTypes.func,
-  className: _react.PropTypes.string
+  id: _propTypes2.default.string,
+  options: _propTypes2.default.object,
+  protocol: _propTypes2.default.string,
+  onTweetLoadSuccess: _propTypes2.default.func,
+  onTweetLoadError: _propTypes2.default.func,
+  className: _propTypes2.default.string
 };
 
 TweetEmbed.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-preset-react-app": "^2.2.0",
     "enzyme": "^2.8.0",
     "jsdom": "^9.12.0",
+    "prop-types": "^15.5.10",
     "react": "^15.4.2",
     "rimraf": "^2.6.1",
     "standard": "^9.0.2"

--- a/tweet-embed.js
+++ b/tweet-embed.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 const callbacks = []
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1862,6 +1862,18 @@ fbjs@^0.8.4:
     promise "^7.1.1"
     ua-parser-js "^0.7.9"
 
+fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -2777,6 +2789,12 @@ loose-envify@^1.0.0, loose-envify@^1.1.0:
   dependencies:
     js-tokens "^2.0.0"
 
+loose-envify@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  dependencies:
+    js-tokens "^3.0.0"
+
 loud-rejection@^1.0.0, loud-rejection@^1.2.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
@@ -3313,6 +3331,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 pseudomap@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -3622,6 +3647,10 @@ set-blocking@~2.0.0:
 set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
 shelljs@^0.7.5:
   version "0.7.5"


### PR DESCRIPTION
Newer versions of React show a deprecation warning when using the old React.PropTypes module:

> Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.

This update uses the new "prop-types" package to suppress the warning.