### PR TITLE
render tweets on props.id change

### DIFF
--- a/tweet-embed.js
+++ b/tweet-embed.js
@@ -16,10 +16,15 @@ function addScript (src, cb) {
 }
 
 class TweetEmbed extends React.Component {
-  componentDidMount () {
+  loadTweetForProps (props) {
     const renderTweet = () => {
       window.twttr.ready().then(({ widgets }) => {
-        const { options, onTweetLoadSuccess, onTweetLoadError } = this.props
+        // Clear previously rendered tweet before rendering the updated tweet id
+        if (this._div) {
+          this._div.innerHTML = ''
+        }
+
+        const { options, onTweetLoadSuccess, onTweetLoadError } = props
         widgets
           .createTweetEmbed(this.props.id, this._div, options)
           .then(onTweetLoadSuccess)
@@ -35,6 +40,18 @@ class TweetEmbed extends React.Component {
     } else {
       renderTweet()
     }
+  }
+
+  componentDidMount () {
+    this.loadTweetForProps(this.props)
+  }
+
+  shouldComponentUpdate (nextProps, nextState) {
+    return this.props.id !== nextProps.id
+  }
+
+  componentWillUpdate (nextProps, nextState) {
+    this.loadTweetForProps(nextProps)
   }
 
   render () {


### PR DESCRIPTION
I have been developing simple react app that shows tweets as flashcards.

`props.id` of `TweetEmbed` component gets changed when the state of my application changes and the tweet corresponding to the `props.id` is not rendered. This PR will handle that case.

## Now
![linuxtweets-now](https://user-images.githubusercontent.com/4211715/35766435-aa9a0f74-08fe-11e8-8cf3-007bec9e10f5.gif)

## After
![linuxtweets-after](https://user-images.githubusercontent.com/4211715/35766375-55917108-08fd-11e8-83f9-dac585bcb74e.gif)

