### PR TITLE
Update on className change

### DIFF
--- a/tweet-embed.js
+++ b/tweet-embed.js
@@ -47,11 +47,16 @@ class TweetEmbed extends React.Component {
   }
 
   shouldComponentUpdate (nextProps, nextState) {
-    return this.props.id !== nextProps.id
+    return (
+      this.props.id !== nextProps.id ||
+      this.props.className !== nextProps.className
+    )
   }
 
   componentWillUpdate (nextProps, nextState) {
-    this.loadTweetForProps(nextProps)
+    if (this.props.id !== nextProps.id) {
+      this.loadTweetForProps(nextProps)
+    }
   }
 
   render () {


### PR DESCRIPTION
Current implementation of react-tweet-embed doesn't update on className changes, so it is not possible to dynamically update className. This commit makes TweetEmbed component update on className change.