### PR TITLE
Allow react 17 on peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/capaj/react-tweet-embed#readme",
   "peerDependencies": {
-    "react": ">17"
+    "react": ">=17"
   },
   "devDependencies": {
     "@types/prop-types": "^15.7.4",


### PR DESCRIPTION
Thanks for your work! I believe React peerDep is meant to be `>=17`, otherwise React v17 will not be included.

![image](https://user-images.githubusercontent.com/2121481/134749970-6b150c89-6433-4e1b-bb7c-eacdd29d9ff7.png)
